### PR TITLE
use pytest to collect test names

### DIFF
--- a/romancal/conftest.py
+++ b/romancal/conftest.py
@@ -19,6 +19,25 @@ from romancal.assign_wcs import pointing
 
 collect_ignore = ["lib/dqflags.py"]
 
+ALL_TEST_NAMES = set()
+
+
+def pytest_collection_modifyitems(config, items):
+    for item in items:
+
+        if not hasattr(item, "module"):
+            # for doctests just use name (since it contains the module)
+            name = item.name
+        else:
+            # otherwise add module
+            name = ".".join((item.module.__name__, item.name))
+        ALL_TEST_NAMES.add(name)
+
+
+@pytest.fixture
+def all_test_names():
+    return ALL_TEST_NAMES
+
 
 @pytest.fixture
 def mk_tmp_dirs():

--- a/romancal/tests/test_requirements.py
+++ b/romancal/tests/test_requirements.py
@@ -1,39 +1,22 @@
 import json
-import re
 from pathlib import Path
 
 TEST_REQUIREMENTS_FILENAME = (
     Path(__file__).parent.parent.parent / "test_requirements.json"
 )
-TEST_DIRECTORY = Path(__file__).parent.parent
 
 
-def test_requirements():
+def test_requirements(all_test_names):
     test_requirements_filename = TEST_REQUIREMENTS_FILENAME.expanduser().absolute()
-    test_directory = TEST_DIRECTORY.expanduser().absolute()
 
     with open(test_requirements_filename) as test_requirements_file:
         requirements = json.load(test_requirements_file)
 
-    required_tests = sorted(
-        {
-            test
-            for requirement_tests in requirements.values()
-            for test in requirement_tests
-        }
-    )
+    required_test_names = {
+        test
+        for requirement_tests in requirements.values()
+        for test in requirement_tests
+    }
 
-    existing_tests = []
-    test_regex = re.compile(r"def (test_[^\(]+)\(.*\):")
-    for test_filename in test_directory.glob("**/test_*.py"):
-        with open(test_filename) as test_file:
-            test_file_contents = test_file.read()
-
-        for match in re.finditer(test_regex, test_file_contents):
-            test = f"{test_directory.stem}.{str(test_filename.relative_to(test_directory).parent).replace('/', '.')}.{test_filename.stem}.{match.group(1)}"
-            if test in required_tests:
-                existing_tests.append(test)
-
-    existing_tests = sorted(existing_tests)
-
-    assert existing_tests == required_tests
+    missing_test_names = required_test_names - all_test_names
+    assert not missing_test_names, f"Missing tests {missing_test_names} required by DMS"


### PR DESCRIPTION
This PR uses a pytest hook to collect the test names and set operations to compare them to the required tests.